### PR TITLE
[Feat] 기존 파일들 수정 및 Main screen 프로토 타입 구현

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -1,7 +1,10 @@
 apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
-
+project.ext.vectoricons = [
+    iconFontNames: [ 'MaterialIcons.ttf','FontAwesome5_Solid.ttf', 'FontAwesome5_Brands.ttf','AntDesign.ttf','FontAwesome.ttf' ] // Name of the font files you want to copy
+]
+apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"
 /**
  * This is the configuration block to customize your React Native Android app.
  * By default you don't need to apply any configuration, just uncomment the lines you need.

--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -1128,6 +1128,10 @@ PODS:
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
+  - RNVectorIcons (10.0.3):
+    - glog
+    - RCT-Folly (= 2022.05.16.00)
+    - React-Core
   - SocketRocket (0.6.1)
   - Yoga (1.14.0)
 
@@ -1209,6 +1213,7 @@ DEPENDENCIES:
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
+  - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -1333,6 +1338,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-reanimated"
   RNScreens:
     :path: "../node_modules/react-native-screens"
+  RNVectorIcons:
+    :path: "../node_modules/react-native-vector-icons"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
@@ -1401,6 +1408,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: bc2cdb2dc42facdf34992ae364b8a728e19a3686
   RNReanimated: 8a4d86eb951a4a99d8e86266dc71d7735c0c30a9
   RNScreens: b6b64d956af3715adbfe84808694ae82d3fec74f
+  RNVectorIcons: 73ab573085f65a572d3b6233e68996d4707fd505
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 805bf71192903b20fc14babe48080582fee65a80
 

--- a/app/ios/app.xcodeproj/project.pbxproj
+++ b/app/ios/app.xcodeproj/project.pbxproj
@@ -9,12 +9,12 @@
 /* Begin PBXBuildFile section */
 		00E356F31AD99517003FC87E /* appTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* appTests.m */; };
 		0C80B921A6F3F58F76C31292 /* libPods-app.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DCACB8F33CDC322A6C60F78 /* libPods-app.a */; };
+		0E1E3E0C09B24FBFBF55508D /* Dongle-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D52DE1D930E84155BF90AD1A /* Dongle-Regular.ttf */; };
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		7699B88040F8A987B510C191 /* libPods-app-appTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 19F6CBCC0A4E27FBF8BF4A61 /* libPods-app-appTests.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
-		0E1E3E0C09B24FBFBF55508D /* Dongle-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D52DE1D930E84155BF90AD1A /* Dongle-Regular.ttf */; };
 		864D44C477AF4C779CABF61E /* Jua-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E2C31140CDF7450CB092ADC4 /* Jua-Regular.ttf */; };
 /* End PBXBuildFile section */
 
@@ -43,11 +43,17 @@
 		5709B34CF0A7D63546082F79 /* Pods-app.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-app.release.xcconfig"; path = "Target Support Files/Pods-app/Pods-app.release.xcconfig"; sourceTree = "<group>"; };
 		5B7EB9410499542E8C5724F5 /* Pods-app-appTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-app-appTests.debug.xcconfig"; path = "Target Support Files/Pods-app-appTests/Pods-app-appTests.debug.xcconfig"; sourceTree = "<group>"; };
 		5DCACB8F33CDC322A6C60F78 /* libPods-app.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-app.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7399DC742BD98A0600F0375B /* AntDesign.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = AntDesign.ttf; path = "../node_modules/react-native-vector-icons/Fonts/AntDesign.ttf"; sourceTree = "<group>"; };
+		7399DC752BD98A0D00F0375B /* FontAwesome5_Solid.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = FontAwesome5_Solid.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Solid.ttf"; sourceTree = "<group>"; };
+		7399DC762BD98A1200F0375B /* FontAwesome.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = FontAwesome.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome.ttf"; sourceTree = "<group>"; };
+		7399DC772BD98A1800F0375B /* MaterialIcons.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = MaterialIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/MaterialIcons.ttf"; sourceTree = "<group>"; };
+		7399DC782BD98A2200F0375B /* FontAwesome5_Brands.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = FontAwesome5_Brands.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Brands.ttf"; sourceTree = "<group>"; };
+		7399DC7A2BD98A8E00F0375B /* MaterialCommunityIcons.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = MaterialCommunityIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/MaterialCommunityIcons.ttf"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = app/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		89C6BE57DB24E9ADA2F236DE /* Pods-app-appTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-app-appTests.release.xcconfig"; path = "Target Support Files/Pods-app-appTests/Pods-app-appTests.release.xcconfig"; sourceTree = "<group>"; };
+		D52DE1D930E84155BF90AD1A /* Dongle-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Dongle-Regular.ttf"; path = "../src/assets/fonts/Dongle-Regular.ttf"; sourceTree = "<group>"; };
+		E2C31140CDF7450CB092ADC4 /* Jua-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Jua-Regular.ttf"; path = "../src/assets/fonts/Jua-Regular.ttf"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
-		D52DE1D930E84155BF90AD1A /* Dongle-Regular.ttf */ = {isa = PBXFileReference; name = "Dongle-Regular.ttf"; path = "../src/assets/fonts/Dongle-Regular.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
-		E2C31140CDF7450CB092ADC4 /* Jua-Regular.ttf */ = {isa = PBXFileReference; name = "Jua-Regular.ttf"; path = "../src/assets/fonts/Jua-Regular.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -90,6 +96,7 @@
 		13B07FAE1A68108700A75B9A /* app */ = {
 			isa = PBXGroup;
 			children = (
+				7399DC722BD988EF00F0375B /* Fonts */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.mm */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
@@ -108,6 +115,19 @@
 				19F6CBCC0A4E27FBF8BF4A61 /* libPods-app-appTests.a */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		7399DC722BD988EF00F0375B /* Fonts */ = {
+			isa = PBXGroup;
+			children = (
+				7399DC742BD98A0600F0375B /* AntDesign.ttf */,
+				7399DC752BD98A0D00F0375B /* FontAwesome5_Solid.ttf */,
+				7399DC762BD98A1200F0375B /* FontAwesome.ttf */,
+				7399DC7A2BD98A8E00F0375B /* MaterialCommunityIcons.ttf */,
+				7399DC772BD98A1800F0375B /* MaterialIcons.ttf */,
+				7399DC782BD98A2200F0375B /* FontAwesome5_Brands.ttf */,
+			);
+			name = Fonts;
 			sourceTree = "<group>";
 		};
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
@@ -154,14 +174,13 @@
 			sourceTree = "<group>";
 		};
 		DFF07D557E004D57A24F0239 /* Resources */ = {
-			isa = "PBXGroup";
+			isa = PBXGroup;
 			children = (
 				D52DE1D930E84155BF90AD1A /* Dongle-Regular.ttf */,
 				E2C31140CDF7450CB092ADC4 /* Jua-Regular.ttf */,
 			);
 			name = Resources;
 			sourceTree = "<group>";
-			path = "";
 		};
 /* End PBXGroup section */
 

--- a/app/ios/app.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/app/ios/app.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/app/ios/app/Info.plist
+++ b/app/ios/app/Info.plist
@@ -51,6 +51,12 @@
 	<array>
 		<string>Dongle-Regular.ttf</string>
 		<string>Jua-Regular.ttf</string>
+		<string>AntDesign.ttf</string>
+		<string>FontAwesome.ttf</string>
+		<string>FontAwesome5_Brands.ttf</string>
+		<string>FontAwesome5_Solid.ttf</string>
+		<string>MaterialCommunityIcons.ttf</string>
+		<string>MaterialIcons.ttf</string>
 	</array>
 </dict>
 </plist>

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -19,6 +19,7 @@
         "react-native-reanimated": "^3.8.1",
         "react-native-safe-area-context": "^4.9.0",
         "react-native-screens": "^3.30.1",
+        "react-native-vector-icons": "^10.0.3",
         "react-redux": "^9.1.1",
         "redux": "^5.0.1",
         "redux-logger": "^3.0.6",
@@ -13998,6 +13999,56 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-vector-icons": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-10.0.3.tgz",
+      "integrity": "sha512-ZgVlV5AdQgnPHHvBEihGf2xwyziT1acpXV1U+WfCgCv3lcEeCRsmwAsBU+kUSNsU+8TcWVsX04kdI6qUaS8D7w==",
+      "dependencies": {
+        "prop-types": "^15.7.2",
+        "yargs": "^16.1.1"
+      },
+      "bin": {
+        "fa-upgrade.sh": "bin/fa-upgrade.sh",
+        "fa5-upgrade": "bin/fa5-upgrade.sh",
+        "fa6-upgrade": "bin/fa6-upgrade.sh",
+        "generate-icon": "bin/generate-icon.js"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-native/node_modules/@jest/types": {

--- a/app/package.json
+++ b/app/package.json
@@ -21,6 +21,7 @@
     "react-native-reanimated": "^3.8.1",
     "react-native-safe-area-context": "^4.9.0",
     "react-native-screens": "^3.30.1",
+    "react-native-vector-icons": "^10.0.3",
     "react-redux": "^9.1.1",
     "redux": "^5.0.1",
     "redux-logger": "^3.0.6",

--- a/app/src/components/common/atom/Container.jsx
+++ b/app/src/components/common/atom/Container.jsx
@@ -1,10 +1,10 @@
 import {View, SafeAreaView} from 'react-native';
-import {moderateScale, scale, verticalScale} from '../../../utils/Scale';
+import {width,height} from '../../../utils/Scale';
 
 const Container = ({children}) => {
   const customStyle = {
-    width: moderateScale(390),
-    height: verticalScale(680),
+    width: width,
+    height: height,
     alignItems: 'center',
   };
 

--- a/app/src/components/common/atom/CustomBtn.jsx
+++ b/app/src/components/common/atom/CustomBtn.jsx
@@ -9,13 +9,13 @@ const CustomBtn = ({onPress, title, size, color, rounded}) => {
   const buttonStyle = {
     width:
       size === 'sm'
-        ? moderateScale(182)
+        ? moderateScale(182,0.3)
         : size === 'md'
-        ? moderateScale(279)
+        ? moderateScale(279,0.3)
         : size === 'lg'
-        ? moderateScale(327)
-        : moderateScale(68),
-    height: size === 'xs' ? verticalScale(34) : verticalScale(48),
+        ? moderateScale(327,0.3)
+        : moderateScale(68,0.3),
+    height: size === 'xs' ? moderateScale(34,0.3) : moderateScale(48,0.3),
     backgroundColor:
       color === 'buttonyellow'
         ? '#faae2b'

--- a/app/src/components/common/atom/CustomTitle.jsx
+++ b/app/src/components/common/atom/CustomTitle.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import {Text} from 'react-native';
-import {moderateScale} from '../../../utils/Scale';
+import { Text } from 'react-native';
+import { moderateScale } from '../../../utils/Scale';
 
-const CustomTitle = ({children}) => {
+const CustomTitle = ({ children, color }) => {
   const customStyle = {
     fontFamily: 'Jua-Regular',
     fontSize: moderateScale(36),
-    color: '#00473e',
+    color: color === "pink" ? '#ffa8ba' : '#00473e', 
   };
 
   return <Text style={customStyle}>{children}</Text>;

--- a/app/src/components/feat_mina/organism/Mainorganism.jsx
+++ b/app/src/components/feat_mina/organism/Mainorganism.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { View } from "react-native";
+import CustomTitle from '../../common/atom/CustomTitle';
+import CustomText from "../../common/atom/CustomText";
+import { styled } from 'nativewind';
+import { scale } from "../../../utils/Scale";
+
+const Body = styled(View)
+
+
+const Mainorganism = () => {
+    
+    return (
+       <Body className="w-full" style={{paddingLeft: scale(20)}}>
+        {/* 메세지 값 서버에서 전달 받아서 출력 */}
+        <CustomTitle color="pink">마음아</CustomTitle>
+        <CustomText></CustomText>
+       </Body>
+    );
+};
+
+export default Mainorganism;

--- a/app/src/components/feat_mina/templates/Maintemplate.jsx
+++ b/app/src/components/feat_mina/templates/Maintemplate.jsx
@@ -1,17 +1,33 @@
+import React from 'react';
+import { View } from "react-native";
+import {TouchableOpacity} from 'react-native-gesture-handler';
+import { styled } from 'nativewind';
 import Container from "../../common/atom/Container";
-import CustomText from "../../common/atom/CustomText";
 import CustomBtn from "../../common/atom/CustomBtn";
+import Icon from 'react-native-vector-icons/MaterialIcons';
+import { moderateScale, scale } from "../../../utils/Scale";
+import Mainorganism from '../organism/Mainorganism';
 
 
+const Header = styled(View)
 
 const Maintemplate = ({ route, navigation, appState }) => {
+    const moveSettingScreen = () => {
+        navigation.push('setting');
+    }
+    
     return (
         <Container>
-            <CustomText>마음아</CustomText>
+            <Header className="w-full flex-row justify-end" style={{padding: scale(20)}}>
+                <TouchableOpacity onPress={moveSettingScreen}>
+                    <Icon name="settings" size={moderateScale(55)} color="darkgray"/>
+                </TouchableOpacity>
+            </Header>
+            <Mainorganism/>
             {/* 이미지 */}
-            <CustomBtn  size="sm" color="buttonyellow" rounded={true} title="회원 가입"/>
+            <CustomBtn  size="sm" color="buttonyellow" rounded={true} title="게임 시작하기"/>
         </Container>
-    )
-}
+    );
+};
 
 export default Maintemplate;

--- a/app/src/components/feat_mina/templates/Maintemplate.jsx
+++ b/app/src/components/feat_mina/templates/Maintemplate.jsx
@@ -1,0 +1,17 @@
+import Container from "../../common/atom/Container";
+import CustomText from "../../common/atom/CustomText";
+import CustomBtn from "../../common/atom/CustomBtn";
+
+
+
+const Maintemplate = ({ route, navigation, appState }) => {
+    return (
+        <Container>
+            <CustomText>마음아</CustomText>
+            {/* 이미지 */}
+            <CustomBtn  size="sm" color="buttonyellow" rounded={true} title="회원 가입"/>
+        </Container>
+    )
+}
+
+export default Maintemplate;

--- a/app/src/navigation/StackNavigation.js
+++ b/app/src/navigation/StackNavigation.js
@@ -32,7 +32,7 @@ const StackNavigation = () => {
   return (
     <NavigationContainer theme={navTheme}>
       <Stack.Navigator
-        initialRouteName={'home'}
+        initialRouteName={'login'}
         screenOptions={customStackNavigationOptions}>
         {/* 로그인 페이지 */}
         <Stack.Screen name="login">

--- a/app/src/navigation/StackNavigation.js
+++ b/app/src/navigation/StackNavigation.js
@@ -8,7 +8,7 @@ import AuthorizationScreen from '../screens/Auth/AuthorizationScreen';
 import Signup1Screen from '../screens/Auth/Signup1Screen';
 import Signup2Screen from '../screens/Auth/Signup2Screen';
 import MainScreen from '../screens/MainScreen';
-
+import SettingScreen from "../screens/Setting/SettingScreen"
 /**
  * StackNavigator를 이용하여서 앱에 대한 페이지 이동을 관리합니다.
  */
@@ -32,8 +32,12 @@ const StackNavigation = () => {
   return (
     <NavigationContainer theme={navTheme}>
       <Stack.Navigator
-        initialRouteName={'login'}
-        screenOptions={customStackNavigationOptions}>
+        initialRouteName={'main'}
+        screenOptions={({ route }) => ({
+          ...customStackNavigationOptions,
+          headerShown: !(route.name === 'login' || route.name === 'main')
+        })}
+      >
         {/* 로그인 페이지 */}
         <Stack.Screen name="login">
           {props => <LoginScreen {...props} />}
@@ -57,6 +61,10 @@ const StackNavigation = () => {
         {/* 메인 페이지 */}
         <Stack.Screen name="main">
           {props => <MainScreen {...props} />}
+        </Stack.Screen>
+        {/* 세팅 페이지 */}
+        <Stack.Screen name="setting">
+          {props => <SettingScreen {...props} />}
         </Stack.Screen>
       </Stack.Navigator>
     </NavigationContainer>

--- a/app/src/screens/Auth/AccountScreen.js
+++ b/app/src/screens/Auth/AccountScreen.js
@@ -6,7 +6,7 @@ const AccountScreen = ({ route, navigation }) => {
   useEffect(() => {}, []);
 
   const moveSignupScreen = () => {
-    navigation.navigate("signup1");
+    navigation.push("signup1");
   };
 
   return (

--- a/app/src/screens/Auth/AuthorizationScreen.js
+++ b/app/src/screens/Auth/AuthorizationScreen.js
@@ -10,7 +10,7 @@ const AuthorizationScreen = ({ route, navigation }) => {
     }, []);
 
     const moveSignup2Screen = () => {
-        navigation.navigate('signup2');
+        navigation.push('signup2');
     }
 
     return (

--- a/app/src/screens/Auth/LoginScreen.js
+++ b/app/src/screens/Auth/LoginScreen.js
@@ -4,23 +4,25 @@ import Container from '../../components/common/atom/Container';
 import CustomTitle from '../../components/common/atom/CustomTitle';
 import BtnBox from '../../components/common/molecules/BtnBox';
 import CustomInput from '../../components/common/atom/CustomInput';
-const LoginScreen = ({ navigation }) => {
-  const moveScreen = useMoveNavigation(navigation);
 
-  const handlePress = (screenName) => {
-    moveScreen(screenName);
-  };
+
+const LoginScreen = ({ navigation }) => {
+  
+  const moveAccountScreen = (screen) => {
+    navigation.push(screen);
+}
+ 
 
   const buttons = [
     {
-      onPress: () => handlePress('account'),
+      onPress: () => moveAccountScreen('account'),
       size: 'sm',
       color: 'buttonyellow',
       rounded: true,
       title: '회원 가입',
     },
     {
-      onPress: () => handlePress('account'),
+      onPress: () => moveAccountScreen('account'),
       size: 'sm',
       color: 'buttonpink',
       rounded: true,

--- a/app/src/screens/Auth/LoginScreen.js
+++ b/app/src/screens/Auth/LoginScreen.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import useMoveNavigation from '../../hooks/useMoveNavigation';
 import Container from '../../components/common/atom/Container';
 import CustomTitle from '../../components/common/atom/CustomTitle';
 import BtnBox from '../../components/common/molecules/BtnBox';

--- a/app/src/screens/Auth/Signup1Screen.js
+++ b/app/src/screens/Auth/Signup1Screen.js
@@ -6,7 +6,7 @@ const Signup1Screen = ({route, navigation}) => {
   useEffect(() => {}, []);
 
   const moveAuthorizationScreen = () => {
-    navigation.navigate('authorization');
+    navigation.push('authorization');
   };
 
   return (

--- a/app/src/screens/Auth/Signup2Screen.js
+++ b/app/src/screens/Auth/Signup2Screen.js
@@ -2,6 +2,16 @@ import React, { useEffect } from "react";
 import { Button, Text, View } from "react-native";
 import { TouchableOpacity } from "react-native-gesture-handler";
 
+import { CommonActions } from '@react-navigation/native';
+
+
+// 회원가입 완료 후 홈 화면으로 리다이렉트
+const resetAction = CommonActions.reset({
+    index: 0,
+    routes: [{ name: 'main' }],
+  });
+ 
+
 
 const Signup2Screen = ({ route, navigation }) => {
 
@@ -10,7 +20,8 @@ const Signup2Screen = ({ route, navigation }) => {
     }, []);
 
     const movemainScreen = () => {
-        navigation.navigate('main');
+        navigation.dispatch(resetAction);
+        //navigation.navigate('main');
     }
 
     return (

--- a/app/src/screens/MainScreen.js
+++ b/app/src/screens/MainScreen.js
@@ -1,14 +1,11 @@
 import React from "react";
 import Maintemplate from "../components/feat_mina/templates/Maintemplate";
 
-
-const MainScreen = () => {
-
+const MainScreen = ({ route, navigation, appState }) => {
     return (
-    <>
-       <Maintemplate/>
-    </>
-    )
-
-}
+        <>
+            <Maintemplate navigation={navigation} />
+        </>
+    );
+};
 export default MainScreen;

--- a/app/src/screens/MainScreen.js
+++ b/app/src/screens/MainScreen.js
@@ -1,16 +1,13 @@
-import React, { useEffect } from "react";
-import { Text, View } from "react-native";
+import React from "react";
+import Maintemplate from "../components/feat_mina/templates/Maintemplate";
 
-const MainScreen = ({ route, navigation, appState }) => {
-    useEffect(() => {
 
-    }, []);
+const MainScreen = () => {
 
     return (
-        <View>
-            <Text> 메인 페이지로 이동하였습니다!!</Text>
-        </View>
-
+    <>
+       <Maintemplate/>
+    </>
     )
 
 }

--- a/app/src/screens/Setting/SettingScreen.js
+++ b/app/src/screens/Setting/SettingScreen.js
@@ -1,0 +1,15 @@
+import React from "react";
+import { Text } from "react-native";
+
+
+
+const SettingScreen = () => {
+
+    return (
+        <>
+         <Text> 세팅 </Text>
+        </>
+    )
+
+}
+export default SettingScreen;

--- a/app/src/utils/Scale.js
+++ b/app/src/utils/Scale.js
@@ -13,4 +13,4 @@ const verticalScale = size => height / guidelineBaseHeight * size;
 // factor값 제어
 const moderateScale = (size, factor = 0.5) => size + ( scale(size) - size ) * factor;
 
-export {scale, verticalScale, moderateScale};
+export {scale, verticalScale, moderateScale, width, height};


### PR DESCRIPTION
## TITLE
> 기존 파일들 수정 및 Main screen 프로토 타입 구현

## 📝작업 내용

> Container, Scale 파일 수정 -> 반응형 레이아웃 구현 
> navigation stack 처리 수정 -> navigate-> push [해당 글 참고](https://velog.io/@fejigu/RN-%ED%99%94%EB%A9%B4-%EA%B0%84-%EC%A0%84%ED%99%98-navigation.navigate-vs-navigation.push-%EC%84%9C%EB%A1%9C-%EB%8B%A4%EB%A5%B8-%ED%83%AD-%EA%B0%84%EC%97%90-%ED%8A%B9%EC%A0%95-%ED%8E%98%EC%9D%B4%EC%A7%80%EC%99%80-%ED%8C%8C%EB%9D%BC%EB%AF%B8%ED%84%B0%EB%A5%BC-%EB%84%98%EA%B8%B0%EB%A0%A4%EB%A9%B4)
> react native vector icon 라이브러리 설치 -> svg로 이미지를 처리 하는 것도 설치 파일이 필요하기에 더 넓은 범위에서 사용 할 수 있는 아이콘 라이브러리를 설치함 (성능을 위해 최소한의 필요 파일만 사용하도록 빌드함 AntDesign.ttf,FontAwesome.ttf, FontAwesome5_Brands.ttf, FontAwesome5_Solid.ttf, MaterialCommunityIcons.ttf, MaterialIcons.ttf)

### 스크린샷

## 💬리뷰 요구사항(선택), Breaking Point

<img width="1866" alt="스크린샷 2024-04-25 오전 5 18 50" src="https://github.com/ddookddook/maeum2_FE/assets/103165845/e2b91954-5f14-44f0-9e1d-c265951ad849">


> 메인 스크린에서 테블릿의 경우 메세지+캐릭터 의 공간이 적음 
> 이 경우 테블릿에서의 디자인을 다시 생각 해봐야 할 것 같음  

## 관련 이슈
- Related #24 
